### PR TITLE
added getRetros to allow retrospective results to be read also

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -58,6 +58,7 @@ export(
   "loglAR1",
   "readADMB",
 	"readVPAFile",
+  "readVPA2Box",
 	"readFLIndex",
 	"read.FLIndex",
 	"readFLIndices",

--- a/R/io.VPA2Box.R
+++ b/R/io.VPA2Box.R
@@ -5,6 +5,48 @@
 # Maintainer: Iago Mosqueira, JRC & Laurie Kell, ICCAT
 # $Id:  $
 
+
+# create retro stocks
+getRetros<-function(stk,fileNm,n){
+  stks<-FLStocks()
+  
+  dir   <-getDir( fileNm)
+  fileNm<-getFile(fileNm)
+  fileNm<-substr( fileNm,1,gregexpr("\\.",fileNm)[[1]]-2)
+  
+  for (iRetro in 0:n){
+    ## Start reading file
+    filename<-paste(dir,.Platform$file.sep,fileNm,iRetro,".R",sep="")
+    
+    ## get Retro estimates
+    i<-0
+    pos1             <-posFile(i,filename)
+    pos2             <-posFile(pos1,filename,char="=")
+    harvest          <-getFLQ(filename,pos1, pos2)
+    
+    pos1             <-posFile(pos2,filename)
+    pos2             <-posFile(pos1,filename,char="=")
+    stock.n          <-getFLQ(filename,pos1, pos2-1)
+    
+    pos1             <-posFile(pos2,filename)
+    pos2             <-posFile(pos1,filename,char="=")
+    catch.n          <-getFLQ(filename,pos1, pos2)
+    
+    stks[[iRetro+1]]<-window(stk,end=dims(harvest)$maxyear)
+    
+    harvest(   stks[[iRetro+1]])<-harvest
+    stock.n(   stks[[iRetro+1]])<-stock.n
+    catch.n(   stks[[iRetro+1]])<-catch.n
+    landings.n(stks[[iRetro+1]])<-catch.n
+    discards.n(stks[[iRetro+1]])[]<-0
+    units(harvest(stks[[iRetro+1]]))<-"f"
+    
+    catch(   stks[[iRetro+1]])<-computeCatch(   stks[[iRetro+1]],'all')
+    landings(stks[[iRetro+1]])<-computeLandings(stks[[iRetro+1]])
+    discards(stks[[iRetro+1]])<-computeDiscards(stks[[iRetro+1]])}
+  
+  return(stks)}
+
 # readVPA2Box {{{
 readVPA2Box <- function(file, args=missing,m=NULL,minage=1,...) {
 

--- a/R/io.VPA2Box.R
+++ b/R/io.VPA2Box.R
@@ -48,10 +48,9 @@ getRetros<-function(stk,fileNm,n){
   return(stks)}
 
 # readVPA2Box {{{
-readVPA2Box <- function(file, args=missing,m=NULL,minage=1,...) {
+readVPA2Box <- function(file,m=NULL,minage=1,retros=TRUE,...) {
 
-  if(!missing(args))
-    args <- c(args, list(...))
+  args <- c(args, list(...))
 
   # control file 
   dir  <- getDir(file)
@@ -181,10 +180,10 @@ readVPA2Box <- function(file, args=missing,m=NULL,minage=1,...) {
   discards(stk) <- computeDiscards(stk)
 
   units(harvest(stk)) <- "f"
-
-  if (nRet > 1)
-    stk <- getRetros(stk,files[3],n=nRet)
-
+  
+   if (nRet>1 & retros)
+     stk <- getRetros(stk,files[3],n=nRet)
+  
   return(stk)
 } # }}}
 


### PR DESCRIPTION
added getRetros to read in retrospective runs also.
There is also a bug in readVPA2Box looks like a function is calling itself. Its OK if io.VPA1box.R is sourced

stk=readVPA2Box("http://rscloud.iccat.int/kobe/bfte/2012/vpa/reported/med/bfte2012.c1")

[1] "bfte2012.d1"  "bfte2012.p1"  "MINUS0.R"     "bfte2012.e1"  "bfte2012.csv"
[6] "none"  
Read 90 items
Read 316 items
Error in filldimnames(dimnames, iter = iter) : 
  promise already under evaluation: recursive default argument reference or earlier problems?
