### PR TITLE
Fix bug in iter() and combine() for FLSR and FLModel

### DIFF
--- a/R/FLModel.R
+++ b/R/FLModel.R
@@ -1158,14 +1158,14 @@ setMethod('combine', signature(x='FLModel', y='FLModel'),
     if(length(dim(vcov(x))) >= 2) {
       vcov(res) <- array(Reduce(c, lapply(args, vcov)),
         dim=c(dim(vcov(x))[1:2], sum(its)),
-        dimnames=c(dimnames(vcov(x))[1:2], list(iter=seq(its))))
+        dimnames=c(dimnames(vcov(x))[1:2], list(iter=seq(sum(its)))))
     }
     
     # hessian
     if(length(dim(hessian(x))) >= 2) {
     hessian(res) <- array(Reduce(c, lapply(args, hessian)),
       dim=c(dim(hessian(x))[1:2], sum(its)),
-      dimnames=c(dimnames(hessian(x))[1:2], list(iter=seq(its))))
+      dimnames=c(dimnames(hessian(x))[1:2], list(iter=seq(sum(its)))))
     }
 
     return(res)

--- a/R/FLModel.R
+++ b/R/FLModel.R
@@ -877,15 +877,15 @@ setMethod("iter", signature(obj="FLModel"),
     # vcov
     if(length(dim(vcov(obj))) > 2)
       if(dim(vcov(obj))[3] > 1)
-        vcov(obj) <- vcov(obj)[,,it]
+        vcov(obj) <- vcov(obj)[,, it, drop = FALSE]
       else
-        vcov(obj) <- vcov(obj)[,,1]
+        vcov(obj) <- vcov(obj)[,, 1, drop = FALSE]
     # hessian
     if(length(dim(hessian(obj))) > 2)
       if(dim(hessian(obj))[3] > 1)
-        hessian(obj) <- hessian(obj)[,,it]
+        hessian(obj) <- hessian(obj)[,, it, drop = FALSE]
       else
-        hessian(obj) <- hessian(obj)[,,1]
+        hessian(obj) <- hessian(obj)[,, 1, drop = FALSE]
     # logLik
     logLik(obj) <- iter(obj@logLik, it)
 

--- a/R/FLModel.R
+++ b/R/FLModel.R
@@ -875,11 +875,17 @@ setMethod("iter", signature(obj="FLModel"),
     # params
     params(obj) <- iter(params(obj), it)
     # vcov
-    if(length(dim(vcov)) > 2)
-      if(dim(vcov)[3] > 1)
+    if(length(dim(vcov(obj))) > 2)
+      if(dim(vcov(obj))[3] > 1)
         vcov(obj) <- vcov(obj)[,,it]
       else
         vcov(obj) <- vcov(obj)[,,1]
+    # hessian
+    if(length(dim(hessian(obj))) > 2)
+      if(dim(hessian(obj))[3] > 1)
+        hessian(obj) <- hessian(obj)[,,it]
+      else
+        hessian(obj) <- hessian(obj)[,,1]
     # logLik
     logLik(obj) <- iter(obj@logLik, it)
 


### PR DESCRIPTION
There are bugs in the methods `iter()` and `combine()` for objects of type `FLModel` and `FLSR`:

1. `iter()`
The dimension is checked for the function `vcov` instead of the slot of the object `vcov(obj)`:
https://github.com/flr/FLCore/blob/4fcace143bd2fafd596a8f01ad7a9880e6ea3f1e/R/FLModel.R#L878-L879
Also, the slot `hessian` of `obj` is ignored.

2. `combine()`
The iter dimension names for vcov and hessian are set based on `seq(its)`
https://github.com/flr/FLCore/blob/4fcace143bd2fafd596a8f01ad7a9880e6ea3f1e/R/FLModel.R#L1155
https://github.com/flr/FLCore/blob/4fcace143bd2fafd596a8f01ad7a9880e6ea3f1e/R/FLModel.R#L1162
instead of `seq(sum(its))`. `seq(its)` incorrectly uses a sequence along the names of the two objects to be combined, instead of using the actual numbers of iterations.

These two errors cause `mp()` from https://github.com/flr/mse to fail when the simulation is split into blocks and then combined later.

Here is a reproducible example:
```
# create example FLSR with 10 iters
library(FLCore)
data("ple4")
sr <- as.FLSR(propagate(ple4, 2))
model(sr) <- "segreg"
sr <- fmle(sr, control = list(trace = 0))
# subset iters
sr1 <- iter(sr, 1)
sr2 <- iter(sr, 2)
# vcov is not subset, 
dim(sr1@vcov)
dim(sr1@vcov)[3] # iter dimension is 2 but should be 1

# combine two FLSRs
sr_combined <- combine(sr, sr)
dim(sr_combined@rec)[6]  # this FLSR object has now 4 iters
dim(sr_combined@vcov)[3] # but vcov has only 2
```